### PR TITLE
fix WPI hang, NSS78 metadata/data, and SSL

### DIFF
--- a/esankhyiki/__init__.py
+++ b/esankhyiki/__init__.py
@@ -54,9 +54,23 @@ def _check_empty_metadata(result, dataset, **params):
     """Raise NoDataError if upstream returned empty filter values."""
     if "error" in result:
         return result
-        
-    data = result.get("filter_values", result.get("data", {}))
-    if isinstance(data, dict):
+
+    _NON_DATA_KEYS = frozenset({"api_params", "statusCode", "dataset", "_note"})
+
+    data = result.get("filter_values", result.get("data", None))
+
+    # If neither "filter_values" nor "data" exists, check the top-level result
+    # for list values (e.g. NSS78 returns {"sub_indicator": [...], "state": [...]})
+    if data is None:
+        top_level_lists = [
+            v for k, v in result.items()
+            if k not in _NON_DATA_KEYS and isinstance(v, list)
+        ]
+        if top_level_lists:
+            is_empty = all(len(v) == 0 for v in top_level_lists)
+        else:
+            is_empty = False
+    elif isinstance(data, dict):
         inner = data.get("data", data)
         if isinstance(inner, dict):
             values = [v for v in inner.values() if isinstance(v, list)]
@@ -388,10 +402,20 @@ def get_data(dataset: str, filters: Dict[str, Any], format: str = "dict"):
         filters = dict(filters)
         filters["type"] = "All"
 
-    # NSS78: map indicator_code to Indicator (API uses capital-I naming)
+    # NSS78: map indicator_code to Indicator name (API expects string name, not code)
     if dataset == "NSS78" and "indicator_code" in filters and "Indicator" not in filters:
         filters = dict(filters)
-        filters["Indicator"] = filters.pop("indicator_code")
+        code = filters.pop("indicator_code")
+        try:
+            code_int = int(code)
+            indicators = _client.get_nss78_indicators().get("indicator", [])
+            name_map = {i["code"]: i["name"] for i in indicators}
+            if code_int in name_map:
+                filters["Indicator"] = name_map[code_int]
+            else:
+                filters["Indicator"] = code
+        except (ValueError, TypeError):
+            filters["Indicator"] = code
 
     api_dataset = DATASET_API_MAP.get(dataset)
     if not api_dataset:

--- a/esankhyiki/client.py
+++ b/esankhyiki/client.py
@@ -6,6 +6,7 @@ Handles all HTTP calls to the MoSPI data portal.
 import math
 import random
 import os
+import ssl
 import yaml
 import requests
 from bs4 import BeautifulSoup
@@ -15,6 +16,23 @@ from urllib3.util.retry import Retry
 
 
 RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class _LegacySSLAdapter(HTTPAdapter):
+    """HTTPAdapter that enables legacy SSL renegotiation.
+
+    The MoSPI API server requires legacy SSL renegotiation which is
+    disabled by default in newer OpenSSL versions. This adapter creates
+    an SSL context with OP_LEGACY_SERVER_CONNECT enabled.
+    """
+
+    def init_poolmanager(self, *args, **kwargs):
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
+        kwargs["ssl_context"] = ctx
+        return super().init_poolmanager(*args, **kwargs)
 
 
 class MoSPI:
@@ -34,7 +52,7 @@ class MoSPI:
             allowed_methods=frozenset({"GET", "POST"}),
             respect_retry_after_header=True,
         )
-        adapter = HTTPAdapter(max_retries=retry)
+        adapter = _LegacySSLAdapter(max_retries=retry)
         self.session.verify = False
         self.session.mount("https://", adapter)
         self.session.mount("http://", adapter)
@@ -243,14 +261,12 @@ class MoSPI:
             return {"error": str(e), "statusCode": False}
 
     def get_wpi_filters(self, base_year: str = "2011-12") -> Dict[str, Any]:
-        params = {"base_year": base_year, "Format": "JSON"}
+        params = {"base_year": base_year}
         try:
-            response = requests.get(
+            response = self.session.get(
                 f"{self.base_url}/api/wpi/getWpiData",
                 params=params,
-                headers={"User-Agent": "Mozilla/5.0"},
-                verify=False,
-                timeout=30,
+                timeout=60,
             )
             response.raise_for_status()
             return response.json()

--- a/esankhyiki/formatters.py
+++ b/esankhyiki/formatters.py
@@ -53,14 +53,29 @@ def _extract_records(result: dict) -> list:
                         lists_of_dicts.append(normalized_values)
             
             if lists_of_dicts:
-                import itertools
-                rows = []
-                for combo in itertools.product(*lists_of_dicts):
-                    row = {}
-                    for d_item in combo:
-                        row.update(d_item)
-                    rows.append(row)
-                return rows
+                # Guard against cartesian explosion on large filter responses
+                # (e.g. WPI with 7 lists of 15-300 items each).
+                # Only compute product for small lists (< 10K combinations).
+                total = 1
+                for lst in lists_of_dicts:
+                    total *= max(len(lst), 1)
+                    if total > 10000:
+                        break
+                if total <= 10000:
+                    import itertools
+                    rows = []
+                    for combo in itertools.product(*lists_of_dicts):
+                        row = {}
+                        for d_item in combo:
+                            row.update(d_item)
+                        rows.append(row)
+                    return rows
+                else:
+                    # Too large for product - flatten each list separately
+                    rows = []
+                    for lst in lists_of_dicts:
+                        rows.extend(lst)
+                    return rows
 
         return []
 
@@ -161,22 +176,23 @@ def format_response(result: dict, fmt: str) -> Union[dict, Any, str]:
             response=result,
         )
 
-    records = _extract_records(result) if isinstance(result, dict) else []
-    if isinstance(result, dict) and (
-        (result.get("msg") == "No Data Found" and not records)
-        or (result.get("troubleshooting") and not records)
-    ):
-        message = result.get("msg")
-        if not message or message == "Data fetched successfully":
-            message = result.get("troubleshooting", "No data found for the requested query.")
-        raise NoDataError(
-            message,
-            dataset=result.get("dataset"),
-            filters=result.get("filters"),
-            troubleshooting=result.get("troubleshooting"),
-            suggestion=result.get("suggestion"),
-            response=result,
-        )
+    # Check for "No Data Found" without calling _extract_records (which can
+    # be expensive for large dict-of-lists responses like WPI filters).
+    if isinstance(result, dict):
+        msg = result.get("msg")
+        ts = result.get("troubleshooting")
+        if msg == "No Data Found" or (ts and not result.get("data")):
+            message = msg if msg and msg != "Data fetched successfully" else (
+                ts or "No data found for the requested query."
+            )
+            raise NoDataError(
+                message,
+                dataset=result.get("dataset"),
+                filters=result.get("filters"),
+                troubleshooting=ts,
+                suggestion=result.get("suggestion"),
+                response=result,
+            )
 
     if fmt == "dict":
         if isinstance(result, dict) and "data" in result:

--- a/esankhyiki/formatters.py
+++ b/esankhyiki/formatters.py
@@ -154,6 +154,17 @@ def to_csv(result: dict) -> str:
     return output.getvalue()
 
 
+def _strip_viz(obj):
+    """Recursively remove 'viz' keys from dicts in the response."""
+    if isinstance(obj, dict):
+        obj.pop("viz", None)
+        for v in obj.values():
+            _strip_viz(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            _strip_viz(item)
+
+
 def format_response(result: dict, fmt: str) -> Union[dict, Any, str]:
     """Apply the requested output format to an API response.
 
@@ -164,6 +175,7 @@ def format_response(result: dict, fmt: str) -> Union[dict, Any, str]:
     Returns:
         dict, pandas.DataFrame, or CSV string.
     """
+    _strip_viz(result)
     fmt = fmt.lower().strip()
 
     if isinstance(result, dict) and "error" in result:


### PR DESCRIPTION
- Fix WPI metadata hanging (cartesian product in formatters on large response)
- Fix NSS78 metadata false empty detection
- Fix NSS78 data indicator_code to name resolution
- Add SSL legacy renegotiation adapter for newer OpenSSL
- WPI get_wpi_filters now uses session instead of raw requests.get