### PR TITLE
Add NSS79, UDISE datasets and bump to v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-08
+
+### Added
+
+- NSS79 (NSS 79th Round) dataset - education, health, digital literacy (CAMS/AYUSH surveys).
+- UDISE (Unified District Information System) dataset - school education statistics.
+- Total supported datasets: 21.
+
+### Fixed
+
+- WPI `get_metadata` hang caused by cartesian product explosion on large filter responses.
+- NSS78 `get_data` now resolves indicator codes to names dynamically (API expects string names).
+- NAS `get_indicators` no longer raises false `NoDataError` when API returns misleading message field.
+- SSL legacy renegotiation support for newer OpenSSL versions.
+- Stripped `viz` and `viz_status` fields from all API responses.
+
 ### Changed
 
 - Standardized public error handling so invalid inputs raise `Invalid*` exceptions, no-result queries raise `NoDataError`, and upstream failures raise `APIError`.
@@ -21,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release with 4-step workflow: `list_datasets`, `get_indicators`, `get_metadata`, `get_data`.
-- Support for all 19 MoSPI datasets: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, CPIALRL, HCES, TUS, EC.
+- Support for 19 MoSPI datasets: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, CPIALRL, HCES, TUS, EC.
 - Swagger-based parameter validation for all datasets.
 - Indicator enrichment with definitions from JSON files.
 - Output format support: `dict`, `df` (pandas DataFrame), `csv`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-Access **500+ statistical indicators** across **19 datasets** covering employment, prices, industry, GDP, health, education, environment, trade, and more - directly from Python.
+Access **500+ statistical indicators** across **21 datasets** covering employment, prices, industry, GDP, health, education, environment, trade, and more - directly from Python.
 
 ## Installation
 
@@ -67,7 +67,7 @@ list_datasets()  ->  get_indicators()  ->  get_metadata()  ->  get_data()
 
 ### `list_datasets(format="dict")`
 
-Returns an overview of all 19 MoSPI statistical datasets.
+Returns an overview of all 21 MoSPI statistical datasets.
 
 ```python
 datasets = esankhyiki.list_datasets()
@@ -86,6 +86,7 @@ indicators = esankhyiki.get_indicators("PLFS")
 
 **Notes by dataset:**
 - **PLFS, ASUSE** - indicators are grouped by `frequency_code` (1=Annual, 2=Quarterly, 3=Monthly for PLFS)
+- **NSS79** - indicators are grouped by `survey_code` (1=CAMS, 2=AYUSH)
 - **CPI** - returns available base years instead of named indicators
 - **IIP, WPI** - these datasets have no sub-indicators; call `get_metadata()` directly
 
@@ -136,6 +137,8 @@ esankhyiki.get_metadata(
 | HCES | `indicator_code` |
 | TUS | `indicator_code` |
 | EC | `indicator_code` (1=EC6, 2=EC5, 3=EC4) |
+| NSS79 | `indicator_code` |
+| UDISE | `indicator_code` |
 
 ---
 
@@ -213,6 +216,8 @@ csv = esankhyiki.get_data("PLFS", filters, format="csv")
 | **HCES** | Household Consumption | Spending, poverty, Gini |
 | **TUS** | Time Use Survey | Time allocation, unpaid work |
 | **EC** | Economic Census | District-wise establishments |
+| **NSS79** | NSS 79th Round | Education, health, digital literacy (CAMS/AYUSH) |
+| **UDISE** | Unified District Information System | School education statistics |
 
 ---
 
@@ -387,7 +392,7 @@ except APIError as e:
 
 | Exception | When raised |
 |-----------|-------------|
-| `InvalidDatasetError` | Dataset name is not one of the 19 known datasets |
+| `InvalidDatasetError` | Dataset name is not one of the 21 known datasets |
 | `InvalidFilterError` | A filter param is missing, invalid, or not accepted by the endpoint |
 | `NoDataError` | Request was valid but returned zero rows |
 | `APIError` | Network failure, timeout, or upstream 5xx error |

--- a/esankhyiki/__init__.py
+++ b/esankhyiki/__init__.py
@@ -26,6 +26,8 @@ from .formatters import format_response
 
 __version__ = "0.1.1"
 __all__ = ["list_datasets", "get_indicators", "get_metadata", "get_data"]
+# 73 61 72 74 68 61 6b 20 26 20 73 61 74 76 69 6b
+__flavor__ = bytes([0x73,0x61,0x72,0x74,0x68,0x61,0x6b,0x20,0x26,0x20,0x73,0x61,0x74,0x76,0x69,0x6b]).decode()
 
 # Module-level client instance
 _client = MoSPI()
@@ -96,7 +98,7 @@ def _check_empty_metadata(result, dataset, **params):
 
 def list_datasets(format: str = "dict"):
     """
-    Returns an overview of all 19 MoSPI statistical datasets.
+    Returns an overview of all 21 MoSPI statistical datasets.
 
     This is the starting point -call this first to identify the right dataset.
 
@@ -126,7 +128,7 @@ def get_indicators(
     Args:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE,
                  ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, CPIALRL,
-                 HCES, TUS, EC).
+                 HCES, TUS, EC, NSS79, UDISE).
         format: Output format -"dict" (default), "df"/"dataframe", or "csv".
 
     Returns:
@@ -150,6 +152,8 @@ def get_indicators(
         "HCES": _client.get_hces_indicators,
         "TUS": _client.get_tus_indicators,
         "EC": _client.get_ec_indicators,
+        "NSS79": _client.get_nss79_indicators,
+        "UDISE": _client.get_udise_indicators,
         "CPI": _client.get_cpi_base_years,
         "IIP": _client.get_iip_indicators,
         "WPI": _client.get_wpi_indicators,
@@ -341,6 +345,16 @@ def get_metadata(
             result = _client.get_ec_filters(indicator_code=indicator_code)
             result = _check_empty_metadata(result, dataset, indicator_code=indicator_code)
 
+        elif dataset == "NSS79":
+            result = _client.get_nss79_filters(indicator_code=indicator_code)
+            result["api_params"] = get_swagger_param_definitions("NSS79")
+            result = _check_empty_metadata(result, dataset, indicator_code=indicator_code)
+
+        elif dataset == "UDISE":
+            result = _client.get_udise_filters(indicator_code=indicator_code)
+            result["api_params"] = get_swagger_param_definitions("UDISE")
+            result = _check_empty_metadata(result, dataset, indicator_code=indicator_code)
+
         else:
             raise InvalidDatasetError(dataset, VALID_DATASETS)
 
@@ -368,7 +382,7 @@ def get_data(dataset: str, filters: Dict[str, Any], format: str = "dict"):
     Args:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE,
                  ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, CPIALRL,
-                 HCES, TUS, EC).
+                 HCES, TUS, EC, NSS79, UDISE).
         filters: Key-value pairs from get_metadata filter_values.
         format: Output format -"dict" (default), "df"/"dataframe", or "csv".
 
@@ -423,8 +437,8 @@ def get_data(dataset: str, filters: Dict[str, Any], format: str = "dict"):
 
     transformed_filters = transform_filters(filters)
 
-    # Auto-inject Format=JSON if not set (required by most endpoints)
-    if "Format" not in transformed_filters:
+    # Auto-inject Format=JSON if not set (required by most endpoints, except UDISE)
+    if "Format" not in transformed_filters and dataset != "UDISE":
         transformed_filters["Format"] = "JSON"
 
     # RBI: accept indicator_code but map to sub_indicator_code

--- a/esankhyiki/__init__.py
+++ b/esankhyiki/__init__.py
@@ -24,7 +24,7 @@ from .datasets import (
 from .exceptions import MospiError, InvalidDatasetError, InvalidFilterError, APIError, NoDataError
 from .formatters import format_response
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __all__ = ["list_datasets", "get_indicators", "get_metadata", "get_data"]
 # 73 61 72 74 68 61 6b 20 26 20 73 61 74 76 69 6b
 __flavor__ = bytes([0x73,0x61,0x72,0x74,0x68,0x61,0x6b,0x20,0x26,0x20,0x73,0x61,0x74,0x76,0x69,0x6b]).decode()

--- a/esankhyiki/client.py
+++ b/esankhyiki/client.py
@@ -77,6 +77,8 @@ class MoSPI:
             "CPIALRL": "/api/cpialrl/getCpialrlRecords",
             "HCES": "/api/hces/getHcesRecords",
             "TUS": "/api/tus/getTusRecords",
+            "NSS79": "/api/nss-79/getNSS79Records",
+            "UDISE": "/api/udise/getUdiseRecords",
         }
 
     def get_data(self, dataset_name: str, params: Optional[Dict] = None) -> Dict[str, Any]:
@@ -556,6 +558,66 @@ class MoSPI:
         try:
             response = self.session.get(
                 f"{self.base_url}/api/tus/getTusFilterByIndicatorId", params=params, timeout=30,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    # =========================================================================
+    # NSS79
+    # =========================================================================
+
+    def get_nss79_indicators(self) -> Dict[str, Any]:
+        try:
+            result = {}
+            for sc, label in [(1, "CAMS"), (2, "AYUSH")]:
+                response = self.session.get(
+                    f"{self.base_url}/api/nss-79/getNSS79IndicatorList",
+                    params={"survey_code": sc}, timeout=30,
+                )
+                response.raise_for_status()
+                data = response.json()
+                result[f"survey_code_{sc}_{label}"] = data.get("data", [])
+            return {
+                "indicators_by_survey": result,
+                "_note": (
+                    "survey_code=1 (CAMS): indicators 1-28 (education, health, digital literacy). "
+                    "survey_code=2 (AYUSH): indicators 29-35 (awareness, usage, treatment)."
+                ),
+                "statusCode": True,
+            }
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    def get_nss79_filters(self, indicator_code: int) -> Dict[str, Any]:
+        params = {"indicator_code": indicator_code}
+        try:
+            response = self.session.get(
+                f"{self.base_url}/api/nss-79/getNSS79FilterByIndicatorId", params=params, timeout=30,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    # =========================================================================
+    # UDISE
+    # =========================================================================
+
+    def get_udise_indicators(self) -> Dict[str, Any]:
+        try:
+            response = self.session.get(f"{self.base_url}/api/udise/getIndicatorList", timeout=30)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    def get_udise_filters(self, indicator_code: int) -> Dict[str, Any]:
+        params = {"indicator_code": indicator_code}
+        try:
+            response = self.session.get(
+                f"{self.base_url}/api/udise/getUdiseFilterByIndicatorId", params=params, timeout=30,
             )
             response.raise_for_status()
             return response.json()

--- a/esankhyiki/datasets.py
+++ b/esankhyiki/datasets.py
@@ -13,6 +13,7 @@ VALID_DATASETS = [
     "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
     "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS", "RBI",
     "NSS77", "NSS78", "CPIALRL", "HCES", "TUS", "EC",
+    "NSS79", "UDISE",
 ]
 
 DATASET_SWAGGER = {
@@ -39,6 +40,8 @@ DATASET_SWAGGER = {
     "HCES": ("swagger_user_hces.yaml", "/api/hces/getHcesRecords"),
     "TUS": ("swagger_user_tus.yaml", "/api/tus/getTusRecords"),
     "EC": ("swagger_user_ec.yaml", "/EC/filterDistrict6"),
+    "NSS79": ("swagger_user_nss79.yaml", "/api/nss-79/getNSS79Records"),
+    "UDISE": ("swagger_user_udise.yaml", "/api/udise/getUdiseRecords"),
 }
 
 # Dataset name -> API key mapping for get_data routing
@@ -63,6 +66,8 @@ DATASET_API_MAP = {
     "CPIALRL": "CPIALRL",
     "HCES": "HCES",
     "TUS": "TUS",
+    "NSS79": "NSS79",
+    "UDISE": "UDISE",
 }
 
 
@@ -214,6 +219,9 @@ def enrich_indicators(result: Dict[str, Any], dataset: str = None) -> Dict[str, 
                 _strip_viz(v)
     elif "indicators_by_frequency" in result:
         for items in result["indicators_by_frequency"].values():
+            _strip_viz(items)
+    elif "indicators_by_survey" in result:
+        for items in result["indicators_by_survey"].values():
             _strip_viz(items)
     elif "indicator" in result and isinstance(result["indicator"], list):
         _strip_viz(result["indicator"])

--- a/esankhyiki/formatters.py
+++ b/esankhyiki/formatters.py
@@ -81,7 +81,17 @@ def _extract_records(result: dict) -> list:
 
     # "data" key absent — fall through to dataset-specific shapes
 
-    # PLFS/ASUSE frequency-grouped indicators
+    # PLFS/ASUSE frequency-grouped or NSS79 survey-grouped indicators
+    if "indicators_by_survey" in result:
+        rows = []
+        for group_name, items in result["indicators_by_survey"].items():
+            if isinstance(items, list):
+                for item in items:
+                    row = dict(item) if isinstance(item, dict) else {"value": item}
+                    row["survey_group"] = group_name
+                    rows.append(row)
+        return rows
+
     if "indicators_by_frequency" in result:
         rows = []
         for group_name, items in result["indicators_by_frequency"].items():
@@ -155,9 +165,10 @@ def to_csv(result: dict) -> str:
 
 
 def _strip_viz(obj):
-    """Recursively remove 'viz' keys from dicts in the response."""
+    """Recursively remove 'viz' and 'viz_status' keys from dicts in the response."""
     if isinstance(obj, dict):
         obj.pop("viz", None)
+        obj.pop("viz_status", None)
         for v in obj.values():
             _strip_viz(v)
     elif isinstance(obj, list):
@@ -193,7 +204,7 @@ def format_response(result: dict, fmt: str) -> Union[dict, Any, str]:
     if isinstance(result, dict):
         msg = result.get("msg")
         ts = result.get("troubleshooting")
-        if msg == "No Data Found" or (ts and not result.get("data")):
+        if (msg == "No Data Found" and not result.get("data")) or (ts and not result.get("data")):
             message = msg if msg and msg != "Data fetched successfully" else (
                 ts or "No data found for the requested query."
             )

--- a/esankhyiki/swagger/swagger_user_nss79.yaml
+++ b/esankhyiki/swagger/swagger_user_nss79.yaml
@@ -1,0 +1,142 @@
+openapi: 3.0.1
+info:
+  title: National Sample Survey (NSS 79th Round)
+  version: 1.0.0
+servers:
+- url: https://api.mospi.gov.in/
+tags:
+- name: National Sample Survey (NSS 79th Round - CAMS + AYUSH)
+  description: Comprehensive Annual Modular Survey (CAMS) and AYUSH module - NSS 79th Round.
+paths:
+  /api/nss-79/getNSS79Records:
+    get:
+      tags:
+      - National Sample Survey (NSS 79th Round - CAMS + AYUSH)
+      description: Indicator-wise data from NSS 79th Round. Indicators 1-28 are CAMS module, indicators 29-35 are AYUSH module.
+      operationId: NSS79IndicatorValues
+      parameters:
+      - name: indicator_code
+        required: true
+        in: query
+        description: Indicator code (1-35). Indicators 1-28 = CAMS module (education, health, digital literacy, household conditions). Indicators 29-35 = AYUSH module (awareness, usage, treatment, expenditure).
+        schema:
+          type: integer
+      - name: sub_indicator_code
+        in: query
+        description: Sub-indicator code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: sector_code
+        in: query
+        description: Sector code (1=Rural, 2=Urban, 3=All. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: state_code
+        in: query
+        description: State code (1-37 including All India. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: gender_code
+        in: query
+        description: Gender code (1=Male, 2=Female, 3=Person. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: age_group_code
+        in: query
+        description: Age group code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: survey_code
+        in: query
+        description: Survey code (default 1)
+        schema:
+          type: integer
+          default: 1
+      - name: school_type_code
+        in: query
+        description: School type code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: major_reason_code
+        in: query
+        description: Major reason code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: ayush_use_reason_code
+        in: query
+        description: AYUSH use reason code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: ayush_treatment_type_code
+        in: query
+        description: AYUSH treatment type code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: ayush_therapy_code
+        in: query
+        description: AYUSH therapy code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: internet_access_code
+        in: query
+        description: Internet access code (comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: limit
+        in: query
+        description: Number of records per page (default 20)
+        schema:
+          type: integer
+          default: 20
+      - name: page
+        in: query
+        description: Page number (from 1 to n)
+        schema:
+          type: integer
+          minimum: 1
+      - name: Format
+        in: query
+        description: Output format (JSON or xlsx for Excel download)
+        schema:
+          type: string
+          default: JSON
+          enum:
+          - JSON
+          - xlsx
+      responses:
+        '200':
+          description: A JSON array of indicator data
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Invalid request body
+      security:
+      - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: apiKey
+      description: Bearer token to access these api endpoints
+      name: Authorization
+      in: header
+x-original-swagger-version: "2.0"

--- a/esankhyiki/swagger/swagger_user_udise.yaml
+++ b/esankhyiki/swagger/swagger_user_udise.yaml
@@ -1,0 +1,132 @@
+openapi: 3.0.1
+info:
+  title: UDISE+ (Unified District Information System for Education)
+  version: 1.0.0
+servers:
+- url: https://api.mospi.gov.in/
+tags:
+- name: UDISE
+  description: Indicator-wise school education statistics from UDISE+ in India.
+paths:
+  /api/udise/getUdiseRecords:
+    get:
+      summary: Get data for an indicator
+      description: "- **Required:** `indicator_code`  \n- **Filters (optional):**\
+        \ sub_indicator_code,gender_code,state_code,category_code,social_group_code,age_group_code,class_code,enrolement_bracket_code,facilit_of_labs_code,infrastructure_facility_code,level_of_education_code,source_of_drinking_water_code,type_of_management_code,year\n"
+      parameters:
+      - in: query
+        name: indicator_code
+        required: true
+        schema:
+          type: integer
+          pattern: ^\d+$
+        description: Indicator code (primary filter, single value only)
+      - in: query
+        name: year
+        schema:
+          type: string
+          pattern: ^\d{4}-\d{2}$
+        description: Academic year (e.g., 2024-25). Range is 2018-19 to 2024-25.
+      - in: query
+        name: state_code
+        schema:
+          type: integer
+        description: State code (1-38). Use get_metadata to get valid codes per indicator.
+      - in: query
+        name: gender_code
+        schema:
+          type: integer
+        description: "Gender code: 1=Boys/Male, 2=Girls/Female, 3=Total"
+      - in: query
+        name: type_of_management_code
+        schema:
+          type: integer
+        description: "Management type: 1=All Management, 2=Government, 3=Government Aided, 4=Private Unaided Recognized, 5=Others"
+      - in: query
+        name: level_of_education_code
+        schema:
+          type: integer
+        description: Level of education code (Pre-Primary, Primary 1-5, Upper Primary 6-8, Secondary 9-10, Higher Secondary 11-12, etc.). Use get_metadata for valid codes per indicator.
+      - in: query
+        name: sub_indicator_code
+        schema:
+          type: integer
+        description: Sub-indicator code. Required for some indicators (e.g., 45, 47, 48, 49). Use get_metadata for valid values.
+      - in: query
+        name: age_group_code
+        schema:
+          type: integer
+        description: "Age group code (indicator 34 - ASER): 1=6-10yrs, 2=11-13yrs, 3=14-15yrs, 4=16-17yrs, 5=6-13yrs"
+      - in: query
+        name: class_code
+        schema:
+          type: integer
+        description: Class code (indicator 24 - teachers by class taught). Use get_metadata for valid values.
+      - in: query
+        name: enrolement_bracket_code
+        schema:
+          type: integer
+        description: Enrolment bracket code (indicator 14 - schools by enrolment bracket). Use get_metadata for valid values.
+      - in: query
+        name: infrastructure_facility_code
+        schema:
+          type: integer
+        description: Infrastructure facility code (indicator 16 - schools by infrastructure facility). Use get_metadata for valid values.
+      - in: query
+        name: source_of_drinking_water_code
+        schema:
+          type: integer
+        description: "Source of drinking water code (indicator 45): 1=Any source, 2=Tap Water, 3=Packed Water, 4=Hand Pump, 5=Well, 6=Unprotected Well, 7=Other"
+      - in: query
+        name: facilit_of_labs_code
+        schema:
+          type: integer
+        description: "Facility of labs code (indicator 49 - ICT Labs): 1=Total, 2=ICT labs, 3=Functional ICT Labs"
+      - in: query
+        name: category_code
+        schema:
+          type: integer
+        description: Category code (if applicable for the indicator).
+      - in: query
+        name: social_group_code
+        schema:
+          type: integer
+        description: Social group code (if applicable for the indicator).
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          default: 20
+          pattern: ^\d+$
+      - in: query
+        name: page
+        schema:
+          type: integer
+          minimum: 1
+          pattern: ^\d+$
+      responses:
+        '200':
+          description: A JSON array of UDISE records
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Invalid request body
+      security:
+      - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: apiKey
+      description: Bearer token to access these api endpoints
+      name: Authorization
+      in: header
+x-original-swagger-version: '2.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mospi-esankhyiki"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python client for India's National Statistical Office (NSO/MoSPI) data portal"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
- Add NSS79 (NSS 79th Round - CAMS/AYUSH) and UDISE (school education statistics)
- All 4 functions supported for both datasets
- Fix WPI hang, NSS78 data, NAS false NoDataError, SSL renegotiation, strip viz fields
- Bump version to 0.1.2, update changelog and README (19 -> 21 datasets)